### PR TITLE
Fix pkgdown build errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MotrpacHumanPreSuspensionAnalysis
 Title: Summary Statistics and Modeling Results from the MoTrPAC Pre-COVID Suspension Phase
-Version: 0.1.0
-Date: Feb 23rd, 2026
+Version: 0.2.0
+Date: Feb 25, 2026
 Authors@R: c(
     person(given = "Christopher", family = "Jin", 
            email = "cajin@stanford.edu", 
@@ -74,8 +74,7 @@ Suggests:
     roxygen2,
     table.glue,
     testthat (>= 3.0.0),
-    variancePartition,
-    MotrpacHumanPreSuspensionData (>= 0.0.1.100)
+    variancePartition
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Remotes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,13 @@ RUN R -e "remotes::install_github('MoTrPAC/MotrpacBicQC', upgrade='never')"
 COPY . /tmp/package
 WORKDIR /tmp/package
 
+# Install all package dependencies declared in DESCRIPTION (Imports/Suggests/Remotes)
+RUN R -e "install.packages('pak', repos='https://cloud.r-project.org')"
+RUN R -e "pak::local_install_dev_deps(dependencies = TRUE)"
+
+# Verify a known required dependency is available before package install
+RUN R -e "if (!requireNamespace('ggpubr', quietly = TRUE)) stop('ggpubr is not installed')"
+
 # Build and install the package with R CMD
 RUN R CMD build --no-build-vignettes . && \
     R CMD INSTALL MotrpacHumanPreSuspensionAnalysis_*.tar.gz

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,22 @@
+# MotrpacHumanPreSuspensionAnalysis 0.2.0
+
+## Documentation and website
+
+- Added pkgdown GitHub Actions workflow for automated website deployment.
+- Added pkgdown configuration updates for GitHub Pages publishing.
+- Clarified consortium-only optional functionality in the README.
+
+## Dependency handling
+
+- Made `MotrpacHumanPreSuspensionData` an optional consortium-only runtime dependency
+  instead of a public package dependency for CI/pkgdown resolution.
+
+# MotrpacHumanPreSuspensionAnalysis 0.1.0
+
+## Initial release
+
+- Public release of summary statistics and modeling outputs from the
+  MoTrPAC human pre-COVID suspension phase.
+- Added functions for loading differential analysis and summary statistics.
+- Added clustering, enrichment, and visualization utilities.
+- Added vignettes and package website scaffolding.

--- a/R/run_SCION.R
+++ b/R/run_SCION.R
@@ -510,6 +510,10 @@ RSGWM2<-function(target.gene.name,
 .load_scion_matrixes = function(desired_matrixes,
                                 subset_TFs = TRUE,
                                 subset_DE = TRUE){
+  check_package_installation(pkg = "MotrpacHumanPreSuspensionData")
+  private_data_ns <- asNamespace("MotrpacHumanPreSuspensionData")
+  private_load_qc <- get("load_qc", envir = private_data_ns, inherits = FALSE)
+
   final_combined_matrix = data.frame()
   for(desired_input in desired_matrixes){
     desired_tissue = sub("\\..*", "", desired_input)
@@ -520,9 +524,9 @@ RSGWM2<-function(target.gene.name,
     if(!all(desired_ome %in% ome_available_list()))
       stop("The syntax for regulators or targets isn't right. Regulators and targets should be in tissue.ome format (e.g blood.transcript-rna-seq)")
 
-    desired_qc_norm_single = MotrpacHumanPreSuspensionData::load_qc(selected_omes = desired_ome,
-                                                                    selected_tissues = desired_tissue,
-                                                                    remove_unnamed_metab = TRUE)
+    desired_qc_norm_single = private_load_qc(selected_omes = desired_ome,
+                         selected_tissues = desired_tissue,
+                         remove_unnamed_metab = TRUE)
     #-------------------------------------------------------------------------------
     # here we handle parameters and use imputed matrixes for prot-(pr/ph)
     if(any(desired_ome == "prot-ph" | desired_ome == "prot-pr")) #have to add 'any' to handle multiple metab platforms
@@ -578,7 +582,11 @@ RSGWM2<-function(target.gene.name,
 .find_shared_scion_matrixes = function(randomGroupCode,
                                        scion_matrix_one,
                                        scion_matrix_two){
-  pheno = MotrpacHumanPreSuspensionData::pheno[["data"]] %>%
+  check_package_installation(pkg = "MotrpacHumanPreSuspensionData")
+  private_data_ns <- asNamespace("MotrpacHumanPreSuspensionData")
+  pheno_object <- get("pheno", envir = private_data_ns, inherits = FALSE)
+
+  pheno = pheno_object[["data"]] %>%
     dplyr::filter(visitcode == "ADU_BAS") %>%
     dplyr::filter(randomGroupCode == !!randomGroupCode)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,11 @@
 
-# Modification of roxygen2:::block_set_env
+# Modification of roxygen2 block_set_env internals
 .custom_block_set_env <- function(block, env) {
-  block <- roxygen2:::block_evaluate(block, env)
-  block <- roxygen2:::block_find_object(block, env)
+  block_evaluate <- getFromNamespace("block_evaluate", "roxygen2")
+  block_find_object <- getFromNamespace("block_find_object", "roxygen2")
+
+  block <- block_evaluate(block, env)
+  block <- block_find_object(block, env)
 
   val <- block[["object"]][["value"]]
 
@@ -15,10 +18,13 @@
   return(block)
 }
 
-# Identical to roxygen2:::block_set_env
+# Identical to roxygen2 block_set_env internals
 .block_set_env <- function(block, env) {
-  block <- roxygen2:::block_evaluate(block, env)
-  block <- roxygen2:::block_find_object(block, env)
+  block_evaluate <- getFromNamespace("block_evaluate", "roxygen2")
+  block_find_object <- getFromNamespace("block_find_object", "roxygen2")
+
+  block <- block_evaluate(block, env)
+  block <- block_find_object(block, env)
 
   return(block)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,6 +84,20 @@ After installation, load the package:
 library(MotrpacHumanPreSuspensionAnalysis)
 ```
 
+## Consortium-only optional features
+
+Most functionality in this package is fully public and works without additional access.
+Some advanced workflows rely on the private package `MotrpacHumanPreSuspensionData`
+that is available only to MoTrPAC consortium members.
+
+At the moment, the primary functions with this optional dependency are:
+
+- `run_SCION()`
+- `plot_precovid_cca()`
+
+If the private package is not installed, these functions will return a clear
+error message with access guidance.
+
 
 
 ## Package Use and Structure

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ After installation, load the package:
 library(MotrpacHumanPreSuspensionAnalysis)
 ```
 
+## Consortium-only optional features
+
+Most functionality in this package is fully public and works without
+additional access. Some advanced workflows rely on the private package
+`MotrpacHumanPreSuspensionData` that is available only to MoTrPAC
+consortium members.
+
+At the moment, the primary functions with this optional dependency are:
+
+- `run_SCION()`
+- `plot_precovid_cca()`
+
+If the private package is not installed, these functions will return a
+clear error message with access guidance.
+
 ## Package Use and Structure
 
 This package is the public release version of the results from the
@@ -258,14 +273,16 @@ summary_stats = load_summary_stats(
   single_matrix = FALSE,
   verbose = TRUE
 )
+#> Only features qualifying for diffential analysis are included. For proteomics and phosphoproteomics, this means some samples with missingness patterns that lead to paired n < 3 for any group are not included here.
+#> Epigenetics summary stats are trimmed to only show significant features due to file size limitations
 names(summary_stats)
 #> [1] "adipose" "blood"   "muscle"
 names(summary_stats[["blood"]])
-#>  [1] "epigen-atac-seq"    "metab-t-amines"     "metab-t-conv"      
-#>  [4] "metab-t-oxylipneg"  "metab-t-tca"        "metab-u-hilicpos"  
-#>  [7] "metab-u-ionpneg"    "metab-u-lrpneg"     "metab-u-lrppos"    
-#> [10] "metab-u-rpneg"      "metab-u-rppos"      "prot-ol"           
-#> [13] "transcript-rna-seq"
+#>  [1] "epigen-atac-seq"      "epigen-methylcap-seq" "metab-t-amines"      
+#>  [4] "metab-t-conv"         "metab-t-oxylipneg"    "metab-t-tca"         
+#>  [7] "metab-u-hilicpos"     "metab-u-ionpneg"      "metab-u-lrpneg"      
+#> [10] "metab-u-lrppos"       "metab-u-rpneg"        "metab-u-rppos"       
+#> [13] "prot-ol"              "transcript-rna-seq"
 ```
 
 By default, load_summary_stats() loads group- and timepoint-level
@@ -288,6 +305,8 @@ upon request via the Motrpac Consortium.
 
 ``` r
 single_matrix = load_summary_stats(single_matrix = TRUE)
+#> Only features qualifying for diffential analysis are included. For proteomics and phosphoproteomics, this means some samples with missingness patterns that lead to paired n < 3 for any group are not included here.
+#> Epigenetics summary stats are trimmed to only show significant features due to file size limitations
 colnames(single_matrix)
 #> [1] "randomGroupCode" "feature_id"      "Timepoint"       "Count"          
 #> [5] "Mean"            "SD"              "tissue"          "assay"


### PR DESCRIPTION
This pull request introduces version 0.2.0 of the `MotrpacHumanPreSuspensionAnalysis` package, focusing on improved dependency handling, clearer documentation for consortium-only features, and updates to internal function usage. The most important changes are grouped below.

**Dependency handling and installation improvements:**

* Made `MotrpacHumanPreSuspensionData` an optional consortium-only runtime dependency, removing it from public package dependencies and CI/pkgdown resolution. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL77-R77) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R22)
* Updated the `Dockerfile` to install all dependencies using `pak` and verify the presence of required packages before installation.

**Documentation and consortium-only feature clarification:**

* Added sections to `README.md` and `README.Rmd` clarifying which features require the private `MotrpacHumanPreSuspensionData` package, including explicit error handling guidance for users without access. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR87-R100) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R92)
* Updated `NEWS.md` with documentation and website deployment changes, including pkgdown workflow and configuration for GitHub Pages.

**Internal code and function updates:**

* Refactored internal functions in `R/run_SCION.R` to use dynamic namespace loading for `MotrpacHumanPreSuspensionData`, enabling runtime checks and clearer error messages for missing dependencies. [[1]](diffhunk://#diff-4afdceaab315f6ea3ec06ed128ec90846f0a05a7c6f0e74ab667563284b659a9R513-R516) [[2]](diffhunk://#diff-4afdceaab315f6ea3ec06ed128ec90846f0a05a7c6f0e74ab667563284b659a9L523-R527) [[3]](diffhunk://#diff-4afdceaab315f6ea3ec06ed128ec90846f0a05a7c6f0e74ab667563284b659a9L581-R589)
* Modified internal roxygen2 helper functions in `R/zzz.R` to use `getFromNamespace` instead of triple-colon access, improving compatibility and maintainability. [[1]](diffhunk://#diff-fbc888a8d95ca11d7f17e5eaa27a08a3d3cb183803ae509deea6aa51f61183fbL2-R8) [[2]](diffhunk://#diff-fbc888a8d95ca11d7f17e5eaa27a08a3d3cb183803ae509deea6aa51f61183fbL18-R27)

**Other updates:**

* Bumped package version and updated metadata in `DESCRIPTION`.
* Expanded summary statistics output and documentation in `README.md` to reflect additional epigenetics and omics features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R276-R285) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R308-R309)